### PR TITLE
Ported to gsl 1.15.3

### DIFF
--- a/_tags
+++ b/_tags
@@ -1,0 +1,2 @@
+<tsinfer.*>: package(gsl), package(str), package(num)
+<io.*>: package(str)


### PR DESCRIPTION
This change renames references to GSL modules to the new names.  The `_tags` file allows you to compile the project with `ocamlbuild -use-ocamlfind tsinfer.native`.  There is no need to use the `Makefile` or know the location of the gsl libraries.
